### PR TITLE
F/update lifecycle to support ipv6

### DIFF
--- a/maestro/lifecycle.py
+++ b/maestro/lifecycle.py
@@ -65,15 +65,18 @@ class TCPPortPinger(RetryingLifecycleHelper):
 
     def _test(self, container=None):
         try:
-            self.host.replace('[','').replace(']','')
             try:
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.settimeout(1)
+                s.connect((self.host, self.port))
+                s.close()
+                return True
             except socket.gaierror:
                 s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-            s.settimeout(1)
-            s.connect((self.host, self.port))
-            s.close()
-            return True
+                s.settimeout(1)
+                s.connect((self.host.replace('[','').replace(']',''), self.port))
+                s.close()
+                return True
         except Exception:
             return False
 

--- a/maestro/lifecycle.py
+++ b/maestro/lifecycle.py
@@ -65,7 +65,11 @@ class TCPPortPinger(RetryingLifecycleHelper):
 
     def _test(self, container=None):
         try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.host.replace('[','').replace(']','')
+            try:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            except socket.gaierror:
+                s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
             s.settimeout(1)
             s.connect((self.host, self.port))
             s.close()


### PR DESCRIPTION
Updated the maestro/lifecycle.py to catch the exception for ipv6 format IP address and use AF_INET6 instead of AF_INET to create the socket.