### PR TITLE
Returning a unique list of ordered container objects from _order_depe…

### DIFF
--- a/maestro/maestro.py
+++ b/maestro/maestro.py
@@ -154,7 +154,7 @@ class Conductor:
         # dependencies. Otherwise, returned the ordered list, which should now
         # be final.
         return wait and self._order_dependencies(wait, ordered, forward) \
-            or ordered
+            or list(set(ordered))
 
     def _gather_dependencies(self, containers, forward=True):
         """Transitively gather all containers from the dependencies or


### PR DESCRIPTION
…ndencies to prevent duplication in term output on repeated calls to orchestrator operations