### PR TITLE
Setting ship defaults for TLS parameters

### DIFF
--- a/maestro/shipproviders.py
+++ b/maestro/shipproviders.py
@@ -51,11 +51,11 @@ class StaticShipsProvider(ShipsProvider):
                 api_version=self._from_ship_or_defaults(v, 'api_version'),
                 timeout=self._from_ship_or_defaults(v, 'timeout'),
                 tls=v.get('tls', False),
-                tls_cert=v.get('tls_cert', None),
-                tls_key=v.get('tls_key', None),
-                tls_verify=v.get('tls_verify', False),
-                tls_ca_cert=v.get('tls_ca_cert', None),
-                ssl_version=v.get('ssl_version', None)))
+                tls_cert=self._from_ship_or_defaults(v, 'tls_cert'),
+                tls_key=self._from_ship_or_defaults(v, 'tls_key'),
+                tls_verify=self._from_ship_or_defaults(v, 'tls_verify'),
+                tls_ca_cert=self._from_ship_or_defaults(v, 'tls_ca_cert'),
+                ssl_version=self._from_ship_or_defaults(v, 'ssl_version')))
             for k, v in self._config['ships'].items())
 
     def ships(self):


### PR DESCRIPTION
Aside from 'tls' parameter, which requires a default value (False) to the ship, all other TLS-related parameters can come from ship defaults as well.

@zsuzhengdu @iangkent @mailjainrahul 